### PR TITLE
Fix invisible asteroid rotation bug

### DIFF
--- a/Asteroid.java
+++ b/Asteroid.java
@@ -1,6 +1,8 @@
 import processing.core.PShape;
 
 public class Asteroid {
+    private static final float DEFAULT_ROTATION_SPEED = 1;
+
     private PShape ast;
     private MainDraw p;
     private float x;
@@ -15,7 +17,7 @@ public class Asteroid {
         x = xpos;
         y = ypos;
         speed = spd;
-        rotationSpeed = rotatSpd;
+        rotationSpeed = safeRotation(rotatSpd);
         angle = ang;
         scale = scl;
         if (Math.random() > 0.49) {
@@ -30,6 +32,7 @@ public class Asteroid {
 
     public void draw() {
         teleBack();
+        rotationSpeed = safeRotation(rotationSpeed);
         p.pushMatrix(); //store current plac e
         p.translate(x, y);
         p.rotate(rotationSpeed);
@@ -95,6 +98,13 @@ public class Asteroid {
         return (int) (Math.random() * size + start);
     }
 
+    private static float safeRotation(float value) {
+        if (value == 0 || Float.isNaN(value) || Float.isInfinite(value)) {
+            return DEFAULT_ROTATION_SPEED;
+        }
+        return value;
+    }
+
     public float getX() {
         return x;
     }
@@ -105,7 +115,7 @@ public class Asteroid {
 
     public float getRotation() {
 //		return (float)Math.toRadians(rotationSpeed);
-        return angle;
+        return rotationSpeed;
     }
 
     public PShape getShape() {

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Asteroids using the Processing library.
 
 <img src="astDemo.gif" width="500" height="500"/>
 
-There's an invisible asteroid.
-It's a bug, but I think that it gives it some charm.
-
+There used to be an invisible asteroid.
+It was a bug, but I think that it gave the game some charm.
+The haunted little rock has now been fixed.
 
 Also, when you crash, stars fly out in all directions. 
 


### PR DESCRIPTION
## Summary
- Prevent asteroid rotation from ever becoming zero, NaN, or infinite
- Use the asteroid's rendered rotation for collision calculations instead of its movement angle

## Why
`rotationSpeed` could randomly start at `0`. On the next draw, the code divided by that value, which made the rotation become infinite. Processing then tried to render the asteroid with a poisoned transform, so the asteroid still existed in the array but vanished from the screen.

Also, `getRotation()` returned the movement angle even though the asteroid was rendered with `rotationSpeed`, so collision math could drift away from what was visible.